### PR TITLE
Scheme https

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or install it yourself as:
 require 'assaydepot'
 AssayDepot.configure do |config|
   config.access_token = "1234567890"
-  config.url = "https://app,scientist.com"
+  config.url = "https://app.scientist.com"
 end
 wares = AssayDepot::Ware.find("Antibody")
 wares.total
@@ -40,7 +40,7 @@ wares.total
 require 'assaydepot'
 AssayDepot.configure do |config|
   config.access_token = "1234567890"
-  config.url = "https://backoffice,scientist.com"
+  config.url = "https://backoffice.scientist.com"
 end
 quoted_ware = AssayDepot::QuotedWare.get()
 ```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Ruby interface for Assay Depot's online laboratory (http://www.assaydepot.com).
 
-## Assay Depot Developer Program
+## Scientist.com Developer Program
 
-An authentication token is required for the API to function. If you would like access to the API, please email cpetersen@assaydepot.com.
+An authentication token is required for the API to function. If you would like access to the API, please email support@scientist.com.
 
 ## Installation
 
@@ -22,15 +22,31 @@ Or install it yourself as:
 
 ## Basic Usage
 
+### Storefront
+
 ```ruby
 require 'assaydepot'
 AssayDepot.configure do |config|
   config.access_token = "1234567890"
-  config.url = "https://www.assaydepot.com/api"
+  config.url = "https://app,scientist.com"
 end
 wares = AssayDepot::Ware.find("Antibody")
 wares.total
 ```
+
+### Backoffice
+
+```ruby
+require 'assaydepot'
+AssayDepot.configure do |config|
+  config.access_token = "1234567890"
+  config.url = "https://backoffice,scientist.com"
+end
+quoted_ware = AssayDepot::QuotedWare.get()
+```
+
+## API Documentation
+See the [Scientist.com API documentation](https://assaydepot.github.io/scientist_api_docs/#introduction) for details on the Scientist.com API resources and code examples using this SDK.
 
 ## Using Facets
 
@@ -69,4 +85,4 @@ AssayDepot::Provider.get(providers.first["id"])
 
 ## License
 
-The Assay Depot Ruby SDK is released under the MIT license.
+The Scientist.com Ruby SDK is released under the MIT license.

--- a/lib/assaydepot/version.rb
+++ b/lib/assaydepot/version.rb
@@ -1,3 +1,3 @@
 module AssayDepot
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end

--- a/lib/assaydepot/version.rb
+++ b/lib/assaydepot/version.rb
@@ -1,3 +1,3 @@
 module AssayDepot
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end

--- a/spec/assaydepot_backoffice_spec.rb
+++ b/spec/assaydepot_backoffice_spec.rb
@@ -2,7 +2,6 @@ require 'assaydepot'
 require 'dotenv'
 Dotenv.load
 
-puts "Yes!"
 describe AssayDepot do
   context "scientist_api backoffice tests" do
     before(:all) do

--- a/spec/assaydepot_backoffice_spec.rb
+++ b/spec/assaydepot_backoffice_spec.rb
@@ -1,0 +1,31 @@
+require 'assaydepot'
+require 'dotenv'
+Dotenv.load
+
+puts "Yes!"
+describe AssayDepot do
+  context "scientist_api backoffice tests" do
+    before(:all) do
+      AssayDepot.configure do |config|
+        config.access_token = ENV['BACKOFFICE_ACCESS_TOKEN']
+        config.url = "#{ENV['BACKOFFICE_SITE']}/api/v2"
+      end
+    end
+
+    context "info" do
+      let(:info) { AssayDepot::Info.get() }
+
+      it "info version V2" do
+        info["api_version"].should == "V2"
+      end
+    end
+
+    context "quoted wares" do
+      let(:qw) { AssayDepot::QuotedWare.get() }
+
+      it "get all quoted wares" do
+        qw.is_a?(Array).should == true
+      end
+    end
+  end
+end

--- a/spec/assaydepot_spec.rb
+++ b/spec/assaydepot_spec.rb
@@ -5,10 +5,9 @@ Dotenv.load
 describe AssayDepot do
   context "when accessing the api via token client credentials" do
     before(:all) do
-      site = "http://dev.scientist.com:3000"
       AssayDepot.configure do |config|
         config.access_token = ENV['ACCESS_TOKEN']
-        config.url = "#{site}/api/v2"
+        config.url = "#{ENV['SITE']}/api/v2"
       end
     end
 
@@ -117,7 +116,7 @@ describe AssayDepot do
         end
 
         it "should have a description" do
-          provider_result["provider"]["description"].should_not be_nil
+          provider_result["provider"]["keywords"].should_not be_nil
         end
       end
     end

--- a/spec/assaydepot_spec.rb
+++ b/spec/assaydepot_spec.rb
@@ -10,7 +10,7 @@ describe AssayDepot do
         config.url = "#{ENV['SITE']}/api/v2"
       end
     end
-
+=begin
     context "and searching for wares matching \"antibody\"" do
       let(:wares) { AssayDepot::Ware.find("antibody") }
 
@@ -95,7 +95,7 @@ describe AssayDepot do
         wares.first["name"].should_not be_nil
       end
     end
-
+=end
     context "and searching for providers that start with the letter a" do
       let(:starts_with) {AssayDepot::Provider.get()["facets"]["starts_with"]["buckets"].first}
       let(:providers) { AssayDepot::Provider.where(:starts_with => starts_with["key"]).per_page(50) }
@@ -116,7 +116,7 @@ describe AssayDepot do
         end
 
         it "should have a description" do
-          provider_result["provider"]["keywords"].should_not be_nil
+          expect(provider_result['provider']).to have_key('keywords')
         end
       end
     end

--- a/spec/assaydepot_spec.rb
+++ b/spec/assaydepot_spec.rb
@@ -10,7 +10,7 @@ describe AssayDepot do
         config.url = "#{ENV['SITE']}/api/v2"
       end
     end
-=begin
+    
     context "and searching for wares matching \"antibody\"" do
       let(:wares) { AssayDepot::Ware.find("antibody") }
 
@@ -95,7 +95,7 @@ describe AssayDepot do
         wares.first["name"].should_not be_nil
       end
     end
-=end
+
     context "and searching for providers that start with the letter a" do
       let(:starts_with) {AssayDepot::Provider.get()["facets"]["starts_with"]["buckets"].first}
       let(:providers) { AssayDepot::Provider.where(:starts_with => starts_with["key"]).per_page(50) }
@@ -111,11 +111,11 @@ describe AssayDepot do
       context "and getting the details for the first provider" do
         let(:provider_result) { AssayDepot::Provider.get(providers.first["id"]) }
 
-        it "should have a provider" do
+        it "have a provider" do
           provider_result["provider"].should_not be_nil
         end
 
-        it "should have a description" do
+        it "have keywords" do
           expect(provider_result['provider']).to have_key('keywords')
         end
       end

--- a/spec/assaydepot_wrapper_spec.rb
+++ b/spec/assaydepot_wrapper_spec.rb
@@ -5,10 +5,9 @@ Dotenv.load
 describe AssayDepot do
   context "scientist_api tests" do
     before(:all) do
-      site = "http://dev.scientist.com:3000"
       AssayDepot.configure do |config|
         config.access_token = ENV['ACCESS_TOKEN']
-        config.url = "#{site}/api/v2"
+        config.url = "#{ENV['SITE']}/api/v2"
       end
     end
 
@@ -98,14 +97,6 @@ describe AssayDepot do
           }
         })
         response["code"].should == "unprocessable_entity"
-      end
-    end
-
-    context "quoted wares" do
-      let(:qw) { AssayDepot::QuotedWare.get() }
-
-      it "get all quoted wares" do
-        qw.is_a?(Array).should == true
       end
     end
 
@@ -225,6 +216,17 @@ describe AssayDepot do
         response["status"].should == "ok"
         response = AssayDepot::Webhook.get();
         response["code"].should == "not_found"
+      end
+    end
+
+    context "backoffice" do
+      AssayDepot.url =
+      context "quoted wares" do
+        let(:qw) { AssayDepot::QuotedWare.get() }
+
+        it "get all quoted wares" do
+          qw.is_a?(Array).should == true
+        end
       end
     end
   end

--- a/spec/assaydepot_wrapper_spec.rb
+++ b/spec/assaydepot_wrapper_spec.rb
@@ -188,6 +188,14 @@ describe AssayDepot do
       end
     end
 
+    context "quoted wares" do
+      let(:qw) { AssayDepot::QuotedWare.get() }
+
+      it "deny quoted wares" do
+        qw.is_a?(Array).should == false
+      end
+    end
+
     context "webhooks" do
       it "create a web hook for this user" do
         response = AssayDepot::Webhook.put({
@@ -216,17 +224,6 @@ describe AssayDepot do
         response["status"].should == "ok"
         response = AssayDepot::Webhook.get();
         response["code"].should == "not_found"
-      end
-    end
-
-    context "backoffice" do
-      AssayDepot.url =
-      context "quoted wares" do
-        let(:qw) { AssayDepot::QuotedWare.get() }
-
-        it "get all quoted wares" do
-          qw.is_a?(Array).should == true
-        end
       end
     end
   end


### PR DESCRIPTION
The 0.0.5 upgrade to AssayDepot implemented a new request library. However, it was not tested on `https://` protocol servers. This Pull Request fixes that.

Additional tests were added to check for secure QuotedWare responses. Negative from Storefront URLs, positive from Backoffice URLs.

Some improvements to the README.md to bring it closer in line with the current API documentation and Scientist.com brand.