### PR TITLE
Dynamic Lists and Purchase Orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.ruby-version
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 gem 'pry'
 gem 'pry-byebug'
-gem 'uri-query_params'
 gem 'dotenv-rails', groups: [:development, :test]
 
 # Specify your gem's dependencies in assaydepot.gemspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Assay Depot ![Build Status](https://secure.travis-ci.org/assaydepot/assaydepot-rb.png) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/assaydepot/assaydepot-rb)
+# Scientist.com
 
-Ruby interface for Assay Depot's online laboratory (http://www.assaydepot.com).
+Ruby interface for Scientist.com's (formerly Assay Depot's) research services marketplace (http://www.scientist.com).
 
 ## Scientist.com Developer Program
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ providers.count
 ## Get Details
 ```ruby
 providers = AssayDepot::Provider.where(:starts_with => "a")
-AssayDepot::Provider.get(providers.first["id"])
+AssayDepot::Provider.get(id: providers.first["id"])
 ```
 
 ## Contributing

--- a/assaydepot.gemspec
+++ b/assaydepot.gemspec
@@ -2,14 +2,14 @@
 require File.expand_path('../lib/assaydepot/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Christopher Petersen"]
-  gem.email         = ["christopher.petersen@gmail.com"]
-  gem.description   = %q{This is the first version of Assay Depot's Ruby SDK. It provides read access to Services and Vendors through assaydepot.com's JSON API.}
+  gem.authors       = ["Christopher Petersen", "Ron Ranauro"]
+  gem.email         = ["chris@scientist.com", "ron@scientist.com"]
+  gem.description   = %q{The Scientist Ruby SDK. It provides read access to Services and Suppliers through scientist.com's JSON API.}
   gem.summary       = %q{Provides read access to Assay Depot's Services and Vendors.}
   gem.homepage      = "https://github.com/assaydepot/assaydepot-rb"
 
   gem.add_dependency('json')
-  gem.add_dependency('uri-query_params')
+  gem.add_dependency('rack')
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rspec')

--- a/lib/assaydepot/client.rb
+++ b/lib/assaydepot/client.rb
@@ -29,7 +29,7 @@ module AssayDepot
       puts "CLIENT.GET HOST [#{uri.host}] URI [#{uri.request_uri}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       res = http.request(request)
-      JSON.parse(res.body)
+      res.body
     end
 
     def put(body: {}, params: {})
@@ -44,7 +44,7 @@ module AssayDepot
         request.body = body.to_json
       end
       res = http.request(request)
-      JSON.parse(res.body)
+      res.body
     end
 
     def post(body: {}, params: {})
@@ -60,7 +60,7 @@ module AssayDepot
         request.body = body.to_json
       end
       res = http.request(request)
-      JSON.parse(res.body)
+      res.body
     end
 
     def delete(params: {})
@@ -71,10 +71,10 @@ module AssayDepot
       puts "CLIENT.DELETE HOST [#{uri.host}] URI [#{uri.request_uri}]}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       res = http.request(request)
-      JSON.parse(res.body)
+      res.body
     end
 
-    def search(query: query, facets: facets, params: params={})
+    def search(query: nil, facets: {}, params: {})
       params["q"] = query if query != ""
       facets&.map do |name,value|
         params["facets[#{name}][]"] = value

--- a/lib/assaydepot/client.rb
+++ b/lib/assaydepot/client.rb
@@ -21,7 +21,7 @@ module AssayDepot
       JSON.parse(res.body)
     end
 
-    def get(params={})
+    def get(params: {})
       uri = get_uri( params )
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
@@ -32,7 +32,7 @@ module AssayDepot
       JSON.parse(res.body)
     end
 
-    def put(body={}, params={})
+    def put(body: {}, params: {})
       uri = get_uri( params )
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
@@ -47,7 +47,7 @@ module AssayDepot
       JSON.parse(res.body)
     end
 
-    def post(body={}, params={})
+    def post(body: {}, params: {})
       uri = get_uri( params )
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
@@ -63,7 +63,7 @@ module AssayDepot
       JSON.parse(res.body)
     end
 
-    def delete(params={})
+    def delete(params: {})
       uri = get_uri( params )
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
@@ -74,12 +74,12 @@ module AssayDepot
       JSON.parse(res.body)
     end
 
-    def search(query, facets, params={})
+    def search(query: query, facets: facets, params: params={})
       params["q"] = query if query != ""
       facets&.map do |name,value|
         params["facets[#{name}][]"] = value
       end
-      get(params)
+      get(params: params)
     end
 
     private

--- a/lib/assaydepot/client.rb
+++ b/lib/assaydepot/client.rb
@@ -26,7 +26,7 @@ module AssayDepot
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Get.new(uri.request_uri)
-      puts "CLIENT.GET [#{uri.host}] [#{uri.port}] [#{uri.request_uri}]" if ENV["DEBUG"] == "true"
+      puts "CLIENT.GET HOST [#{uri.host}] URI [#{uri.request_uri}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       res = http.request(request)
       JSON.parse(res.body)
@@ -37,6 +37,7 @@ module AssayDepot
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Put.new(uri.request_uri)
+      puts "CLIENT.PUT HOST [#{uri.host}] URI [#{uri.request_uri}] BODY [#{body.inspect}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       request["Content-Type"] = "application/json"
       if (body.keys.length > 0)
@@ -51,10 +52,11 @@ module AssayDepot
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Post.new(uri.request_uri)
+      puts "CLIENT.POST HOST [#{uri.host}] URI [#{uri.request_uri}] BODY [#{body.inspect}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       request["Accept"] = "application/json"
       request["Content-Type"] = "application/json"
-      if (body.keys.length > 0)
+      if (body && body.keys.length > 0)
         request.body = body.to_json
       end
       res = http.request(request)
@@ -66,6 +68,7 @@ module AssayDepot
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Delete.new(uri.request_uri)
+      puts "CLIENT.DELETE HOST [#{uri.host}] URI [#{uri.request_uri}]}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       res = http.request(request)
       JSON.parse(res.body)

--- a/lib/assaydepot/endpoints.rb
+++ b/lib/assaydepot/endpoints.rb
@@ -39,6 +39,10 @@ module AssayDepot
   class QuoteGroup
     include ::AssayDepot::SearchModel
 
+    def self.mine
+      get(id: "mine")
+    end
+
     def self.endpoint(id=nil, format="json")
       get_endpoint(id, "quote_groups", format)
     end
@@ -102,6 +106,10 @@ module AssayDepot
 
   class User
     include ::AssayDepot::SearchModel
+
+    def self.profile
+      get(id: "profile")
+    end
 
     def self.endpoint(id=nil, format="json")
       get_endpoint(id == nil || id[0] == nil ? nil : 'profile', "users", format)

--- a/lib/assaydepot/endpoints.rb
+++ b/lib/assaydepot/endpoints.rb
@@ -188,4 +188,37 @@ module AssayDepot
       "purchase_orders"
     end
   end
+
+  class List
+    include ::AssayDepot::DatabaseModel
+
+    def self.create(slug, name)
+      post(body: { slug: slug, name: name })
+    end
+
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id, "dynamic_lists", format)
+    end
+
+    def self.ref_name
+      "dynamic_lists"
+    end
+  end
+
+  class ListItem
+    include ::AssayDepot::SearchModel
+
+    def self.endpoint(id, format="json")
+      if (id.is_a?(Array) && id.length > 1)
+        url = "/dynamic_lists/#{id[0]}/items/#{id[1]}.#{format}"
+      else
+        url = "/dynamic_lists/#{id.is_a?(Array) ? id[0] : id}/items.#{format}"
+      end
+      url
+    end
+
+    def self.ref_name
+      "items"
+    end
+  end
 end

--- a/lib/assaydepot/endpoints.rb
+++ b/lib/assaydepot/endpoints.rb
@@ -1,10 +1,10 @@
 module AssayDepot
 
   class Category
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint(id, "categories")
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id, "categories", format)
     end
 
     def self.ref_name
@@ -13,34 +13,34 @@ module AssayDepot
   end
 
   class DynamicForm
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint(id, "dynamic_forms")
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id, "dynamic_forms", format)
     end
   end
 
   class Info
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint(nil, "info")
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(nil, "info", format)
     end
   end
 
   class Organization
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint(id, "organizations")
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id, "organizations", format)
     end
   end
 
   class QuoteGroup
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint(id, "quote_groups")
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id, "quote_groups", format)
     end
 
     def self.ref_name
@@ -49,10 +49,10 @@ module AssayDepot
   end
 
   class AddNote
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id)
-      "/quote_groups/#{id}/add_note"
+    def self.endpoint(id, format="json")
+      "/quote_groups/#{id}/add_note.#{format}"
     end
 
     def self.ref_name
@@ -61,10 +61,10 @@ module AssayDepot
   end
 
   class QuotedWare
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint(id, "quoted_wares")
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id, "quoted_wares", format)
     end
 
     def self.ref_name
@@ -73,10 +73,10 @@ module AssayDepot
   end
 
   class Provider
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint( id, "providers" )
+    def self.endpoint(id=nil, format="json")
+      get_endpoint( id, "providers", format)
     end
 
     def self.search_type
@@ -89,10 +89,10 @@ module AssayDepot
   end
 
   class ProviderWare
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id)
-      "/providers/#{id.is_a?(Array) ? id[0] : id}/wares.json"
+    def self.endpoint(id, format="json")
+      "/providers/#{id.is_a?(Array) ? id[0] : id}/wares.#{format}"
     end
 
     def self.ref_name
@@ -101,10 +101,10 @@ module AssayDepot
   end
 
   class User
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint(id == nil || id[0] == nil ? nil : 'profile', "users")
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id == nil || id[0] == nil ? nil : 'profile', "users", format)
     end
 
     def self.ref_name
@@ -113,10 +113,10 @@ module AssayDepot
   end
 
   class Ware
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint( id, "wares" )
+    def self.endpoint(id=nil, format="json")
+      get_endpoint( id, "wares", format)
     end
 
     def self.search_type
@@ -129,13 +129,13 @@ module AssayDepot
   end
 
   class WareProvider
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id)
+    def self.endpoint(id, format="json")
       if (id.is_a?(Array) && id.length > 1)
-        url = "/wares/#{id[0]}/providers/#{id[1]}.json"
+        url = "/wares/#{id[0]}/providers/#{id[1]}.#{format}"
       else
-        url = "/wares/#{id.is_a?(Array) ? id[0] : id}/providers.json"
+        url = "/wares/#{id.is_a?(Array) ? id[0] : id}/providers.#{format}"
       end
       url
     end
@@ -146,10 +146,10 @@ module AssayDepot
   end
 
   class Webhook
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(id=nil)
-      get_endpoint(id, "webhook_config")
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id, "webhook_config", format)
     end
 
     def self.ref_name
@@ -158,14 +158,26 @@ module AssayDepot
   end
 
   class TokenAuth
-    include ::AssayDepot::Model
+    include ::AssayDepot::SearchModel
 
-    def self.endpoint(site="")
+    def self.endpoint(site="", format=nil)
       "#{site}/oauth/token?grant_type=client_credentials"
     end
 
     def self.ref_name
       "access_token"
+    end
+  end
+
+  class PurchaseOrder
+    include ::AssayDepot::DatabaseModel
+
+    def self.endpoint(id=nil, format="json")
+      get_endpoint(id, "purchase_orders", format)
+    end
+
+    def self.ref_name
+      "purchase_orders"
     end
   end
 end

--- a/lib/assaydepot/model.rb
+++ b/lib/assaydepot/model.rb
@@ -22,7 +22,7 @@ module AssayDepot
     # Overridden from Model
     def internal_results
       unless @internal_results
-        @internal_results = Client.new(endpoint: self.class.endpoint(nil)).get(params: @internal_options)
+        @internal_results = JSON.parse(Client.new(endpoint: self.class.endpoint(nil)).get(params: @internal_options))
       end
       @internal_results
     end
@@ -75,7 +75,8 @@ module AssayDepot
     # Overridden from Model
     def internal_results
       unless @internal_results
-        @internal_results = Client.new(endpoint: self.class.endpoint(nil)).search(query: search_query, facets: search_facets, params: internal_options)
+        results = Client.new(endpoint: self.class.endpoint(nil)).search(query: search_query, facets: search_facets, params: internal_options)
+        @internal_results = JSON.parse(results)
       end
       @internal_results
     end
@@ -97,27 +98,37 @@ module AssayDepot
       # optional "id" followed by optional hash
       def get(id: nil, params: {}, format: "json")
         puts "GET id #{id}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).get(params: params)
+        result = Client.new(endpoint: endpoint(id, format)).get(params: params)
+        return JSON.parse(result) if format == "json"
+        result
       end
 
       def put(id: nil, body: nil, params: {}, format: "json")
         puts "PUT id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).put( body: body, params: params )
+        result = Client.new(endpoint: endpoint(id, format)).put( body: body, params: params )
+        return JSON.parse(result) if format == "json"
+        result
       end
 
       def patch(id: nil, body: nil, params: {}, format: "json")
         puts "PATCH id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).put( body: body, params: params )
+        result = Client.new(endpoint: endpoint(id, format)).put( body: body, params: params )
+        return JSON.parse(result) if format == "json"
+        result
       end
 
       def post(id: nil, body: nil, params: {}, format: "json")
         puts "POST id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).post( body: body, params: params )
+        result = Client.new(endpoint: endpoint(id, format)).post( body: body, params: params )
+        return JSON.parse(result) if format == "json"
+        result
       end
 
       def delete(id: nil, body: nil, params: {}, format: "json")
         puts "DELETE id #{id}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).delete(params: params)
+        result = Client.new(endpoint: endpoint(id, format)).delete(params: params)
+        return JSON.parse(result) if format == "json"
+        result
       end
     end
 

--- a/lib/assaydepot/model.rb
+++ b/lib/assaydepot/model.rb
@@ -22,7 +22,7 @@ module AssayDepot
     # Overridden from Model
     def internal_results
       unless @internal_results
-        @internal_results = Client.new(endpoint: self.class.endpoint(nil)).get(@internal_options)
+        @internal_results = Client.new(endpoint: self.class.endpoint(nil)).get(params: @internal_options)
       end
       @internal_results
     end
@@ -75,7 +75,7 @@ module AssayDepot
     # Overridden from Model
     def internal_results
       unless @internal_results
-        @internal_results = Client.new(endpoint: self.class.endpoint(nil)).search(search_query, search_facets, internal_options)
+        @internal_results = Client.new(endpoint: self.class.endpoint(nil)).search(query: search_query, facets: search_facets, params: internal_options)
       end
       @internal_results
     end
@@ -97,27 +97,27 @@ module AssayDepot
       # optional "id" followed by optional hash
       def get(id: nil, params: {}, format: "json")
         puts "GET id #{id}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).get(params)
+        Client.new(endpoint: endpoint(id, format)).get(params: params)
       end
 
       def put(id: nil, body: nil, params: {}, format: "json")
         puts "PUT id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).put( body, params )
+        Client.new(endpoint: endpoint(id, format)).put( body: body, params: params )
       end
 
       def patch(id: nil, body: nil, params: {}, format: "json")
         puts "PATCH id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).put( body, params )
+        Client.new(endpoint: endpoint(id, format)).put( body: body, params: params )
       end
 
       def post(id: nil, body: nil, params: {}, format: "json")
         puts "POST id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).post( body, params )
+        Client.new(endpoint: endpoint(id, format)).post( body: body, params: params )
       end
 
       def delete(id: nil, body: nil, params: {}, format: "json")
         puts "DELETE id #{id}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).delete(params)
+        Client.new(endpoint: endpoint(id, format)).delete(params: params)
       end
     end
 

--- a/lib/assaydepot/model.rb
+++ b/lib/assaydepot/model.rb
@@ -1,18 +1,35 @@
 require 'forwardable'
 module AssayDepot
-  module Model
+  module DatabaseModel
     module ClassMethods
-
-      def get_token(client_id, client_secret, site)
-        response = Client.new.request(AssayDepot::TokenAuth.endpoint(site), {}, {}, {:username => client_id, :password => client_secret})
-        response[AssayDepot::TokenAuth.ref_name]
+      def all(options = {})
+        self.new.all(options)
       end
+    end
 
-      def get_endpoint( id, endpoint )
-        id = id[0] if id && id.kind_of?(Array)
-        id ? "#{endpoint}/#{id}.json" : "#{endpoint}.json"
+    def self.included(base)
+      base.include AssayDepot::Model
+      base.extend AssayDepot::Model::ClassMethods
+      base.extend ClassMethods
+    end
+
+    def all(options = {})
+      result = self.clone
+      result.internal_options = options
+      result
+    end
+
+    # Overridden from Model
+    def internal_results
+      unless @internal_results
+        @internal_results = Client.new(endpoint: self.class.endpoint(nil)).get(@internal_options)
       end
+      @internal_results
+    end
+  end
 
+  module SearchModel
+    module ClassMethods
       # find and where to modify params
       def find(query)
         self.new.find(query)
@@ -21,36 +38,92 @@ module AssayDepot
       def where(conditions={})
         self.new.where(conditions)
       end
+    end
+
+    def self.included(base)
+      base.extend AssayDepot::Model::ClassMethods
+      base.extend ClassMethods
+      base.include AssayDepot::Model
+      base.include AssayDepot::Pageable
+
+      attr_accessor :search_query
+      attr_accessor :search_facets
+    end
+
+    def initialize(options={})
+      @internal_options = options[:search_options] || { }
+      @search_query = options[:search_query] || ""
+      @search_facets = options[:search_facets] || { }
+    end
+
+    def facets
+      internal_results["facets"]
+    end
+
+    def find(query)
+      result = self.clone
+      result.search_query = query
+      result
+    end
+
+    def where(conditions={})
+      result = self.clone
+      result.search_facets = self.search_facets ? self.search_facets.merge(conditions) : conditions
+      result
+    end
+
+    # Overridden from Model
+    def internal_results
+      unless @internal_results
+        @internal_results = Client.new(endpoint: self.class.endpoint(nil)).search(search_query, search_facets, internal_options)
+      end
+      @internal_results
+    end
+  end
+
+  module Model
+    module ClassMethods
+      def get_token(client_id, client_secret, site)
+        response = Client.new.request(AssayDepot::TokenAuth.endpoint(site), {}, {}, {:username => client_id, :password => client_secret})
+        response[AssayDepot::TokenAuth.ref_name]
+      end
+
+      def get_endpoint( id, endpoint, format = "json")
+        id = id[0] if id && id.kind_of?(Array)
+        id ? "#{endpoint}/#{id}.#{format}" : "#{endpoint}.#{format}"
+      end
 
       # HTTP request verbs
       # optional "id" followed by optional hash
-      def get(*id, **params)
-        Client.new(:endpoint => endpoint(id)).get(params)
+      def get(*id, **params, format)
+        puts "PUT id #{id}, params #{params}" if ENV["DEBUG"] == "true"
+        Client.new(endpoint: endpoint(id, format)).get(params)
       end
 
-      def put(*id, **params)
-
+      def put(*id, **params, format)
         id, body, params = get_variable_args(id, params)
-        # puts "id #{id}, body #{body.to_s}, params #{params}"
-        Client.new(:endpoint => endpoint(id)).put( body, params )
+        puts "PUT id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
+        Client.new(endpoint: endpoint(id, format)).put( body, params )
       end
 
-      def patch(*id, **params)
+      def patch(*id, **params, format)
         id, body, params = get_variable_args(id, params)
-        Client.new(:endpoint => endpoint(id)).put( body, params )
+        puts "PATCH id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
+        Client.new(endpoint: endpoint(id, format)).put( body, params )
       end
 
-      def post(*id, **params)
+      def post(*id, **params, format)
         id, body, params = get_variable_args(id, params)
-        Client.new(:endpoint => endpoint(id)).post( body, params )
+        puts "POST id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
+        Client.new(endpoint: endpoint(id, format)).post( body, params )
       end
 
-      def delete(*id, **params)
-        Client.new(:endpoint => endpoint(id)).delete(params)
+      def delete(*id, **params, format)
+        puts "DELETE id #{id}, params #{params}" if ENV["DEBUG"] == "true"
+        Client.new(endpoint: endpoint(id, format)).delete(params)
       end
 
       def get_variable_args(id, params)
-
         if (id && id.length > 1 && (id[1].is_a?(Integer) || id[1].is_a?(String)))
           body = params
           params = {}
@@ -98,73 +171,58 @@ module AssayDepot
                       :reject,
                       :reverse
 
-      attr_accessor :search_query
-      attr_accessor :search_facets
-      attr_accessor :search_options
+      attr_accessor :internal_options
+    end
 
-      def initialize(options={})
-        @search_query = options[:search_query] || ""
-        @search_facets = options[:search_facets] || {}
-        @search_options = options[:search_options] || {:page => 1}
-      end
+    def initialize(options={})
+      @internal_options = options[:search_options] || { }
+    end
 
-      def initialize_copy(source)
-        super
-        @search_query = @search_query.dup
-        @search_facets = @search_facets.dup
-      end
+    def initialize_copy(source)
+      super
+      @search_query = @search_query.dup
+      @search_facets = @search_facets.dup
+    end
 
-      def query_time
-        search_results["query_time"]
-      end
-      def total
-        search_results["total"]
-      end
-      def page
-        search_results["page"]
-      end
-      def per_page
-        search_results["per_page"]
-      end
-      def facets
-        search_results["facets"]
-      end
+    def query_time
+      internal_results["query_time"]
+    end
 
-      def page(page_num)
-        options( { "page" => page_num } )
-      end
+    def total
+      internal_results["total"]
+    end
 
-      def per_page(page_size)
-        options( { "per_page" => page_size } )
-      end
+    def options(options={})
+      result = self.clone
+      result.internal_options = self.internal_options ? self.internal_options.merge(options) : options
+      result
+    end
 
-      def find(query)
-        result = self.clone
-        result.search_query = query
-        result
-      end
+    def private_results
+      internal_results[self.class.ref_name]
+    end
 
-      def where(conditions={})
-        result = self.clone
-        result.search_facets = self.search_facets ? self.search_facets.merge(conditions) : conditions
-        result
-      end
+    # def internal_results
+    #   # To be overridden
+    #   # If I leave this method in, it gets called, possibly a problem with the order of inclusion
+    # end
+  end
 
-      def options(options={})
-        result = self.clone
-        result.search_options = self.search_options ? self.search_options.merge(options) : options
-        result
-      end
+  module Pageable
+    def page
+      internal_results["page"]
+    end
 
-      def private_results
-        search_results[self.class.ref_name]
-      end
-      def search_results
-        unless @search_results
-          @search_results = Client.new(:endpoint => self.class.endpoint(nil)).search(search_query, search_facets, search_options)
-        end
-        @search_results
-      end
+    def per_page
+      internal_results["per_page"]
+    end
+
+    def page(page_num)
+      options( { "page" => page_num } )
+    end
+
+    def per_page(page_size)
+      options( { "per_page" => page_size } )
     end
   end
 end

--- a/lib/assaydepot/model.rb
+++ b/lib/assaydepot/model.rb
@@ -95,29 +95,29 @@ module AssayDepot
 
       # HTTP request verbs
       # optional "id" followed by optional hash
-      def get(id: nil, params: {})
+      def get(id: nil, params: {}, format: "json")
         puts "GET id #{id}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id)).get(params)
+        Client.new(endpoint: endpoint(id, format)).get(params)
       end
 
-      def put(id: nil, body: nil, params: {})
+      def put(id: nil, body: nil, params: {}, format: "json")
         puts "PUT id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id)).put( body, params )
+        Client.new(endpoint: endpoint(id, format)).put( body, params )
       end
 
-      def patch(id: nil, body: nil, params: {})
+      def patch(id: nil, body: nil, params: {}, format: "json")
         puts "PATCH id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id)).put( body, params )
+        Client.new(endpoint: endpoint(id, format)).put( body, params )
       end
 
-      def post(id: nil, body: nil, params: {})
+      def post(id: nil, body: nil, params: {}, format: "json")
         puts "POST id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id)).post( body, params )
+        Client.new(endpoint: endpoint(id, format)).post( body, params )
       end
 
-      def delete(id: nil, body: nil, params: {})
+      def delete(id: nil, body: nil, params: {}, format: "json")
         puts "DELETE id #{id}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id)).delete(params)
+        Client.new(endpoint: endpoint(id, format)).delete(params)
       end
     end
 

--- a/lib/assaydepot/model.rb
+++ b/lib/assaydepot/model.rb
@@ -101,14 +101,11 @@ module AssayDepot
       end
 
       def put(id: nil, body: nil, params: {})
-      # def put(*id, **params)
-      #   id, body, params = get_variable_args(id, params)
         puts "PUT id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
         Client.new(endpoint: endpoint(id)).put( body, params )
       end
 
       def patch(id: nil, body: nil, params: {})
-        # id, body, params = get_variable_args(id, params)
         puts "PATCH id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
         Client.new(endpoint: endpoint(id)).put( body, params )
       end
@@ -121,28 +118,6 @@ module AssayDepot
       def delete(id: nil, body: nil, params: {})
         puts "DELETE id #{id}, params #{params}" if ENV["DEBUG"] == "true"
         Client.new(endpoint: endpoint(id)).delete(params)
-      end
-
-      def get_variable_args(id, params)
-        if (id && id.length > 1 && (id[1].is_a?(Integer) || id[1].is_a?(String)))
-          body = params
-          params = {}
-        elsif (id && id.length > 1)
-          body = id[1]
-          id = id[0]
-        elsif (id && id[0].is_a?(Hash))
-          body = id.last
-          id = nil
-        elsif (id && id.length == 1 && id[0].is_a?(Hash) == false)
-          body = params
-          id = id[0]
-          params = {}
-        else
-          body = params
-          params = {}
-          id = nil
-        end
-        [id, body, params]
       end
     end
 

--- a/lib/assaydepot/model.rb
+++ b/lib/assaydepot/model.rb
@@ -95,32 +95,32 @@ module AssayDepot
 
       # HTTP request verbs
       # optional "id" followed by optional hash
-      def get(*id, **params, format)
+      def get(*id, **params)
         puts "PUT id #{id}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).get(params)
+        Client.new(endpoint: endpoint(id)).get(params)
       end
 
-      def put(*id, **params, format)
+      def put(*id, **params)
         id, body, params = get_variable_args(id, params)
         puts "PUT id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).put( body, params )
+        Client.new(endpoint: endpoint(id)).put( body, params )
       end
 
-      def patch(*id, **params, format)
+      def patch(*id, **params)
         id, body, params = get_variable_args(id, params)
         puts "PATCH id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).put( body, params )
+        Client.new(endpoint: endpoint(id)).put( body, params )
       end
 
-      def post(*id, **params, format)
+      def post(*id, **params)
         id, body, params = get_variable_args(id, params)
         puts "POST id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).post( body, params )
+        Client.new(endpoint: endpoint(id)).post( body, params )
       end
 
-      def delete(*id, **params, format)
+      def delete(*id, **params)
         puts "DELETE id #{id}, params #{params}" if ENV["DEBUG"] == "true"
-        Client.new(endpoint: endpoint(id, format)).delete(params)
+        Client.new(endpoint: endpoint(id)).delete(params)
       end
 
       def get_variable_args(id, params)

--- a/lib/assaydepot/model.rb
+++ b/lib/assaydepot/model.rb
@@ -88,37 +88,37 @@ module AssayDepot
         response[AssayDepot::TokenAuth.ref_name]
       end
 
-      def get_endpoint( id, endpoint, format = "json")
+      def get_endpoint(id, endpoint, format = "json")
         id = id[0] if id && id.kind_of?(Array)
         id ? "#{endpoint}/#{id}.#{format}" : "#{endpoint}.#{format}"
       end
 
       # HTTP request verbs
       # optional "id" followed by optional hash
-      def get(*id, **params)
-        puts "PUT id #{id}, params #{params}" if ENV["DEBUG"] == "true"
+      def get(id: nil, params: {})
+        puts "GET id #{id}, params #{params}" if ENV["DEBUG"] == "true"
         Client.new(endpoint: endpoint(id)).get(params)
       end
 
-      def put(*id, **params)
-        id, body, params = get_variable_args(id, params)
+      def put(id: nil, body: nil, params: {})
+      # def put(*id, **params)
+      #   id, body, params = get_variable_args(id, params)
         puts "PUT id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
         Client.new(endpoint: endpoint(id)).put( body, params )
       end
 
-      def patch(*id, **params)
-        id, body, params = get_variable_args(id, params)
+      def patch(id: nil, body: nil, params: {})
+        # id, body, params = get_variable_args(id, params)
         puts "PATCH id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
         Client.new(endpoint: endpoint(id)).put( body, params )
       end
 
-      def post(*id, **params)
-        id, body, params = get_variable_args(id, params)
+      def post(id: nil, body: nil, params: {})
         puts "POST id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
         Client.new(endpoint: endpoint(id)).post( body, params )
       end
 
-      def delete(*id, **params)
+      def delete(id: nil, body: nil, params: {})
         puts "DELETE id #{id}, params #{params}" if ENV["DEBUG"] == "true"
         Client.new(endpoint: endpoint(id)).delete(params)
       end

--- a/lib/assaydepot/version.rb
+++ b/lib/assaydepot/version.rb
@@ -1,3 +1,3 @@
 module AssayDepot
-  VERSION = "0.0.8"
+  VERSION = "0.1.0"
 end

--- a/spec/assaydepot_spec.rb
+++ b/spec/assaydepot_spec.rb
@@ -10,7 +10,7 @@ describe AssayDepot do
         config.url = "#{ENV['SITE']}/api/v2"
       end
     end
-    
+
     context "and searching for wares matching \"antibody\"" do
       let(:wares) { AssayDepot::Ware.find("antibody") }
 
@@ -23,7 +23,7 @@ describe AssayDepot do
       end
 
       context "and getting the details for the first ware" do
-        let(:ware_result) { AssayDepot::Ware.get(wares.first["id"]) }
+        let(:ware_result) { AssayDepot::Ware.get(id: wares.first["id"]) }
 
         it "should have a ware" do
           ware_result["ware"].should_not be_nil
@@ -109,7 +109,7 @@ describe AssayDepot do
       end
 
       context "and getting the details for the first provider" do
-        let(:provider_result) { AssayDepot::Provider.get(providers.first["id"]) }
+        let(:provider_result) { AssayDepot::Provider.get(id: providers.first["id"]) }
 
         it "have a provider" do
           provider_result["provider"].should_not be_nil

--- a/spec/assaydepot_wrapper_spec.rb
+++ b/spec/assaydepot_wrapper_spec.rb
@@ -26,7 +26,7 @@ describe AssayDepot do
       end
 
       it "get specific category" do
-        category = AssayDepot::Category.get(categories[AssayDepot::Category.ref_name].first[:id])
+        category = AssayDepot::Category.get(id: categories[AssayDepot::Category.ref_name].first[:id])
         categories[AssayDepot::Category.ref_name][0][:id].should == category[:id]
       end
     end
@@ -39,7 +39,7 @@ describe AssayDepot do
       end
 
       it "get specific organization" do
-        organization = AssayDepot::Organization.get(organizations.first["id"])
+        organization = AssayDepot::Organization.get(id: organizations.first["id"])
         organizations.first["id"].should == organization["id"]
       end
     end
@@ -53,28 +53,28 @@ describe AssayDepot do
 
       it "get specific provider" do
         id = providers[AssayDepot::Provider.ref_name].first["id"]
-        provider = AssayDepot::Provider.get(id)
+        provider = AssayDepot::Provider.get(id: id)
         id.is_a?(Integer).should == true
         id.should == provider["provider"]["id"]
       end
 
       it "get wares for a specific provider" do
         id = providers[AssayDepot::Provider.ref_name].first["id"]
-        ware = AssayDepot::ProviderWare.get(id)
+        ware = AssayDepot::ProviderWare.get(id: id)
         ware[AssayDepot::ProviderWare.ref_name].is_a?(Array).should == true
       end
 
       it "update specific provider attribute" do
         id = providers[AssayDepot::Provider.ref_name].first["id"]
         num_employees = rand(1000)
-        response = AssayDepot::Provider.put(id, {number_of_employees: num_employees});
+        response = AssayDepot::Provider.put(id: id, body: { number_of_employees: num_employees });
         response["code"].should == "forbidden"
       end
 
     end
 
     context "quote groups" do
-      let(:qg) { AssayDepot::QuoteGroup.get('mine')}
+      let(:qg) { AssayDepot::QuoteGroup.mine }
 
       it "quote groups mine" do
         qg[AssayDepot::QuoteGroup.ref_name].is_a?(Array).should == true
@@ -82,7 +82,7 @@ describe AssayDepot do
 
       it "quote groups specific id" do
         id = qg[AssayDepot::QuoteGroup.ref_name].first["id"]
-        response = AssayDepot::QuoteGroup.get( id )
+        response = AssayDepot::QuoteGroup.get( id: id )
         response["id"].should == id
       end
 
@@ -90,7 +90,7 @@ describe AssayDepot do
         id = qg[AssayDepot::QuoteGroup.ref_name].first["id"]
         title_text = "This is some #{rand(1000)} text."
         body_text = "This is some #{rand(1000)} body text."
-        response = AssayDepot::AddNote.post(id, {
+        response = AssayDepot::AddNote.post(id: id, body: {
           note: {
             title: title_text,
             body: body_text
@@ -102,7 +102,7 @@ describe AssayDepot do
 
     context "users" do
       let(:users) { AssayDepot::User.get() }
-      let(:profile) { AssayDepot::User.get('profile') }
+      let(:profile) { AssayDepot::User.profile }
 
       it "get all users" do
         users[AssayDepot::User.ref_name].is_a?(Array).should == true
@@ -121,12 +121,12 @@ describe AssayDepot do
       end
 
       it "get specific ware" do
-        ware = AssayDepot::Ware.get( wares[AssayDepot::Ware.ref_name].first["id"] )
+        ware = AssayDepot::Ware.get( id: wares[AssayDepot::Ware.ref_name].first["id"] )
         wares[AssayDepot::Ware.ref_name].first["id"].should == ware["ware"]["id"]
       end
 
       it "get providers for a ware id" do
-        response = AssayDepot::WareProvider.get( wares[AssayDepot::Ware.ref_name].first["id"] )
+        response = AssayDepot::WareProvider.get( id: wares[AssayDepot::Ware.ref_name].first["id"] )
         response[AssayDepot::WareProvider.ref_name].is_a?(Array).should == true
       end
     end
@@ -140,15 +140,15 @@ describe AssayDepot do
         @provider_id = providers[AssayDepot::Provider.ref_name].first["id"]
         @provider_name = providers[AssayDepot::Provider.ref_name].first["name"]
         sleep(1)
-        @delete = AssayDepot::WareProvider.delete( @ware_id, @provider_id )
-        @ware_provider_response = AssayDepot::WareProvider.post( @ware_id, @provider_id )
+        @delete = AssayDepot::WareProvider.delete( id: [@ware_id, @provider_id] )
+        @ware_provider_response = AssayDepot::WareProvider.post( id: [@ware_id, @provider_id] )
         # TODO: this should not be needed
         sleep(2)
-        @ware_provider = AssayDepot::WareProvider.get( @ware_id )
-        @provider_ware = AssayDepot::ProviderWare.get( @provider_id )
-        @clean_up = AssayDepot::WareProvider.delete( @ware_id, @provider_id )
-        @provider_clean_up = AssayDepot::WareProvider.get( @ware_id )
-        @ware_clean_up = AssayDepot::ProviderWare.get( @provider_id )
+        @ware_provider = AssayDepot::WareProvider.get( id: @ware_id )
+        @provider_ware = AssayDepot::ProviderWare.get( id: @provider_id )
+        @clean_up = AssayDepot::WareProvider.delete( id: [@ware_id, @provider_id] )
+        @provider_clean_up = AssayDepot::WareProvider.get( id: @ware_id )
+        @ware_clean_up = AssayDepot::ProviderWare.get( id: @provider_id )
       end
 
       it "make sure provider is not published" do
@@ -198,7 +198,7 @@ describe AssayDepot do
 
     context "webhooks" do
       it "create a web hook for this user" do
-        response = AssayDepot::Webhook.put({
+        response = AssayDepot::Webhook.put(body: {
           name: "This is another new 'name'.",
           bogus_key: "ignore_me"
         })
@@ -208,7 +208,7 @@ describe AssayDepot do
       end
 
       it "create a web hook for this user (patch) and verify (get)" do
-        response = AssayDepot::Webhook.patch({
+        response = AssayDepot::Webhook.patch(body: {
           name: "And another new 'name'.",
           bogus_key: "ignore_me"
         })


### PR DESCRIPTION
This replaces #4 which can be closed without merging.

Includes
 * Adds support for PurchaseOrders
 * Adds support for non-JSON endpoint (PDF specifically). This means moving the JSON parsing out of the `Client` and into the `Model`.
 * Makes the `get`, `put`, `patch`, `post` and `delete` model methods take named parameters. This is a breaking change for apps using the SDK (more below).
 * Adds support for Lists and ListItems
 * Switched from `uri-query_params` and `URI.encode_www_form` to `rack` and `Rack::Utils.build_nested_query` because the former does not properly support rails style nested parameters.
 * Broke `Model` out into a super class and created `SearchModel` and `DatabaseModel` because the simpler (non-search based) models don't need a bunch of the fancier `where` stuff.


## Breaking change
The named parameter change is a breaking change for existing apps (like Sci2Lead). This can be mitigated by the version referenced in the `Gemfile` of the other apps.

I've bumped the version to `0.1.0` from `0.0.8`, so other apps can lock to that version or a similar version using:

`gem "assaydepot", "0.0.8"`

or 

`gem "assaydepot", "~> 0.0.8"`
