### PR TITLE
enhancements to support sci2lead

### DIFF
--- a/lib/assaydepot/client.rb
+++ b/lib/assaydepot/client.rb
@@ -10,12 +10,14 @@ module AssayDepot
       @endpoint = options[:endpoint]
     end
 
-    def request(url, params={}, headers={}, auth={})
-      uri = URI( "#{url}" )
+    def request(url = nil, params={}, headers={}, auth={})
+      uri = url.nil? ? get_uri(params) : URI( "#{url}" )
+      puts "CLIENT.REQUEST HOST [#{uri.host}] URI [#{uri.request_uri}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
       uri.query = Rack::Utils.build_nested_query(params) unless params.keys.length == 0
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Get.new(uri.request_uri)
+      request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token] || auth[:username]
       request.basic_auth auth[:username], auth[:password] unless auth[:username].nil?
       res = http.request(request)
       JSON.parse(res.body)

--- a/lib/assaydepot/endpoints.rb
+++ b/lib/assaydepot/endpoints.rb
@@ -67,6 +67,18 @@ module AssayDepot
   class QuotedWare
     include ::AssayDepot::SearchModel
 
+    def self.proposals(id, format="json")
+      get(id: "#{id[:id]}/proposals", format: format)
+    end
+
+    def self.purchase_orders(id, format="json")
+      get(id: "#{id[:id]}/purchase_orders", format: format)
+    end
+
+    def self.messages(id, format="json")
+      get(id: "#{id[:id]}/messages", format: format)
+    end
+
     def self.endpoint(id=nil, format="json")
       get_endpoint(id, "quoted_wares", format)
     end

--- a/lib/assaydepot/version.rb
+++ b/lib/assaydepot/version.rb
@@ -1,3 +1,3 @@
 module AssayDepot
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
This pull request addresses the issues described here: https://github.com/assaydepot/assaydepot-rb/issues/6

What is changed?
- Added 3 endpoints to `AssayDepot::QuotedWare`: `proposals`, `purchase_orders`, `messages`.
- Added generic `Request` method along side standard verbs `GET`, `PUT`, etc. This allows wrapper to handle API endpoints in generic fashion.

These issues have been tested as part of the Sci2Lead development and test on the command line. As such there are no additional specs. Since API testing requires data and is handled as part of the API development we could consider adding wrapper tests to the API spec development. 