### PR TITLE
added logger to configuration and replace puts calls

### DIFF
--- a/lib/assaydepot.rb
+++ b/lib/assaydepot.rb
@@ -5,6 +5,7 @@ require "assaydepot/model"
 require "assaydepot/core"
 require "assaydepot/endpoints"
 require "assaydepot/event"
+require "logger"
 
 module AssayDepot
   class SignatureVerificationError < StandardError
@@ -19,5 +20,13 @@ module AssayDepot
       @exception_type = exception_type
       super(msg)
     end
+  end
+
+  def self.logger
+    @@logger ||= defined?(Rails) ? Rails.logger : ::Logger.new(STDOUT)
+  end
+
+  def self.logger=(logger)
+    @@logger = logger
   end
 end

--- a/lib/assaydepot/client.rb
+++ b/lib/assaydepot/client.rb
@@ -12,7 +12,7 @@ module AssayDepot
 
     def request(url = nil, params={}, headers={}, auth={})
       uri = url.nil? ? get_uri(params) : URI( "#{url}" )
-      puts "CLIENT.REQUEST HOST [#{uri.host}] URI [#{uri.request_uri}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
+      AssayDepot.logger.debug "CLIENT.REQUEST HOST [#{uri.host}] URI [#{uri.request_uri}] PARAMS [#{params.inspect}]"
       uri.query = Rack::Utils.build_nested_query(params) unless params.keys.length == 0
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
@@ -28,7 +28,7 @@ module AssayDepot
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Get.new(uri.request_uri)
-      puts "CLIENT.GET HOST [#{uri.host}] URI [#{uri.request_uri}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
+      AssayDepot.logger.debug "CLIENT.GET HOST [#{uri.host}] URI [#{uri.request_uri}] PARAMS [#{params.inspect}]"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       res = http.request(request)
       res.body
@@ -39,7 +39,7 @@ module AssayDepot
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Put.new(uri.request_uri)
-      puts "CLIENT.PUT HOST [#{uri.host}] URI [#{uri.request_uri}] BODY [#{body.inspect}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
+      AssayDepot.logger.debug "CLIENT.PUT HOST [#{uri.host}] URI [#{uri.request_uri}] BODY [#{body.inspect}] PARAMS [#{params.inspect}]"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       request["Content-Type"] = "application/json"
       if (body.keys.length > 0)
@@ -54,7 +54,7 @@ module AssayDepot
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Post.new(uri.request_uri)
-      puts "CLIENT.POST HOST [#{uri.host}] URI [#{uri.request_uri}] BODY [#{body.inspect}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
+      AssayDepot.logger.debug "CLIENT.POST HOST [#{uri.host}] URI [#{uri.request_uri}] BODY [#{body.inspect}] PARAMS [#{params.inspect}]"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       request["Accept"] = "application/json"
       request["Content-Type"] = "application/json"
@@ -70,7 +70,7 @@ module AssayDepot
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme === 'https'
       request = Net::HTTP::Delete.new(uri.request_uri)
-      puts "CLIENT.DELETE HOST [#{uri.host}] URI [#{uri.request_uri}]}] PARAMS [#{params.inspect}]" if ENV["DEBUG"] == "true"
+      AssayDepot.logger.debug "CLIENT.DELETE HOST [#{uri.host}] URI [#{uri.request_uri}]}] PARAMS [#{params.inspect}]"
       request["Authorization"] = "Bearer #{AssayDepot.access_token}" unless params[:access_token]
       res = http.request(request)
       res.body

--- a/lib/assaydepot/model.rb
+++ b/lib/assaydepot/model.rb
@@ -97,35 +97,35 @@ module AssayDepot
       # HTTP request verbs
       # optional "id" followed by optional hash
       def get(id: nil, params: {}, format: "json")
-        puts "GET id #{id}, params #{params}" if ENV["DEBUG"] == "true"
+        AssayDepot.logger.debug "GET id #{id}, params #{params}"
         result = Client.new(endpoint: endpoint(id, format)).get(params: params)
         return JSON.parse(result) if format == "json"
         result
       end
 
       def put(id: nil, body: nil, params: {}, format: "json")
-        puts "PUT id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
+        AssayDepot.logger.debug "PUT id #{id}, body #{body.to_s}, params #{params}"
         result = Client.new(endpoint: endpoint(id, format)).put( body: body, params: params )
         return JSON.parse(result) if format == "json"
         result
       end
 
       def patch(id: nil, body: nil, params: {}, format: "json")
-        puts "PATCH id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
+        AssayDepot.logger.debug "PATCH id #{id}, body #{body.to_s}, params #{params}"
         result = Client.new(endpoint: endpoint(id, format)).put( body: body, params: params )
         return JSON.parse(result) if format == "json"
         result
       end
 
       def post(id: nil, body: nil, params: {}, format: "json")
-        puts "POST id #{id}, body #{body.to_s}, params #{params}" if ENV["DEBUG"] == "true"
+        AssayDepot.logger.debug "POST id #{id}, body #{body.to_s}, params #{params}"
         result = Client.new(endpoint: endpoint(id, format)).post( body: body, params: params )
         return JSON.parse(result) if format == "json"
         result
       end
 
       def delete(id: nil, body: nil, params: {}, format: "json")
-        puts "DELETE id #{id}, params #{params}" if ENV["DEBUG"] == "true"
+        AssayDepot.logger.debug "DELETE id #{id}, params #{params}"
         result = Client.new(endpoint: endpoint(id, format)).delete(params: params)
         return JSON.parse(result) if format == "json"
         result

--- a/lib/assaydepot/version.rb
+++ b/lib/assaydepot/version.rb
@@ -1,3 +1,3 @@
 module AssayDepot
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/assaydepot_backoffice_spec.rb
+++ b/spec/assaydepot_backoffice_spec.rb
@@ -1,4 +1,5 @@
 require 'assaydepot'
+require 'logger'
 require 'dotenv'
 Dotenv.load
 
@@ -9,6 +10,7 @@ describe AssayDepot do
         config.access_token = ENV['BACKOFFICE_ACCESS_TOKEN']
         config.url = "#{ENV['BACKOFFICE_SITE']}/api/v2"
       end
+      AssayDepot.logger.level = Logger::ERROR
     end
 
     context "configuration" do

--- a/spec/assaydepot_backoffice_spec.rb
+++ b/spec/assaydepot_backoffice_spec.rb
@@ -11,6 +11,21 @@ describe AssayDepot do
       end
     end
 
+    context "configuration" do
+      it "default logger" do
+        AssayDepot.logger.class == Logger
+      end
+
+      it "custom logger" do
+        logger = AssayDepot.logger
+        AssayDepot.configure do |config|
+          config.logger = "my custom logger"
+        end
+        AssayDepot.logger == 'my custom logger'
+        AssayDepot.logger = logger
+      end
+    end
+
     context "info" do
       let(:info) { AssayDepot::Info.get() }
 

--- a/spec/assaydepot_spec.rb
+++ b/spec/assaydepot_spec.rb
@@ -1,4 +1,5 @@
 require 'assaydepot'
+require 'logger'
 require 'dotenv'
 Dotenv.load
 
@@ -9,6 +10,7 @@ describe AssayDepot do
         config.access_token = ENV['ACCESS_TOKEN']
         config.url = "#{ENV['SITE']}/api/v2"
       end
+      AssayDepot.logger.level = Logger::ERROR
     end
 
     context "and searching for wares matching \"antibody\"" do

--- a/spec/assaydepot_wrapper_spec.rb
+++ b/spec/assaydepot_wrapper_spec.rb
@@ -1,4 +1,5 @@
 require 'assaydepot'
+require 'logger'
 require 'dotenv'
 Dotenv.load
 


### PR DESCRIPTION
Addresses issue [Add a logger](https://github.com/assaydepot/assaydepot-rb/issues/8)

Developers can add a custom logger as described in the issue:

```
logger = Logger.new(STDOUT)
logger.level = ENV['DEBUG'] =="true" ? Logger::DEBUG : Logger::ERROR
AssayDepot.configure do |config|
  config.access_token = "1234567890"
  config.url = "https://backoffice.scientist.com"
  config.logger = logger
end
```
If no logger is defined by the configuration the default logger will be used. In the case of Rails this will be the Rails logger, or the standard Ruby logger if running standalone.

The `puts` statements in the wrapper library were replaced with `AssayDepot.logger.debug` statements and will only show when the `logger.level = Logger::DEBUG`

A simple configuration test was added to `spec/assaydepot_backoffice_spec.rb` to confirm the configuration logic is working.
